### PR TITLE
fix type clash between mocha and jest

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "forceConsistentCasingInFileNames": true,
     "removeComments": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["gzip-js", "jest", "react", "react-dom"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fixes a type clash between `mocha` and `jest`.

Both libraries share the same globals which clash: [Thread](https://github.com/cypress-io/cypress/issues/1087)

[There appears to be a fix in the develop branch of Cypress](https://github.com/cypress-io/cypress/pull/3425) which is currently unavailable.

There are two possible workarounds. The one i've provided narrows down the types and the alternate approach is to enable `skipLibChecks` which is less than ideal. 

Related issues:
- https://github.com/cypress-io/cypress/issues/6690
- https://github.com/cypress-io/cypress/issues/6156