### PR TITLE
Adding a host to allow stories to use hooks

### DIFF
--- a/src/task-runner/repeat-element.tsx
+++ b/src/task-runner/repeat-element.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
 
+/**
+ * Elements need a host to render within so that hooks defined in a story
+ * can attach to some host.
+ */
+const NodeHost = ({ getNode }: { getNode: () => React.ReactNode }): React.ReactElement => {
+  return <>{getNode()}</>;
+};
+
 export default function repeatElement(
   getNode: () => React.ReactNode,
   copies: number,
 ): React.ReactElement {
   const nodes: React.ReactNode[] = Array.from({ length: copies }, (_, key) => (
-    <React.Fragment key={key}>{getNode()}</React.Fragment>
+    <React.Fragment key={key}>
+      <NodeHost getNode={getNode} />}
+    </React.Fragment>
   ));
   return <React.Fragment>{nodes}</React.Fragment>;
 }


### PR DESCRIPTION
#### Description of changes
Added a host component to render stories so that hooks within story examples can run in the context of.

This should resolve issue #11 and #2 but there might be a better way to resolve these issues.
