### PR TITLE
Emit TS declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "storybook:build": "yarn build && yarn build-storybook",
     "typescript:check": "yarn tsc --noEmit",
     "typescript:watch": "tsc --watch",
-    "typescript:build": "tsc",
+    "typescript:build": "tsc --declaration",
     "prettier:check": "yarn prettier --debug-check $npm_package_config_prettier_target",
     "prettier:write": "yarn prettier --write $npm_package_config_prettier_target",
     "eslint:check": "eslint $npm_package_config_prettier_target --max-warnings=0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "storybook:build": "yarn build && yarn build-storybook",
     "typescript:check": "yarn tsc --noEmit",
     "typescript:watch": "tsc --watch",
-    "typescript:build": "tsc --declaration",
+    "typescript:build": "tsc",
     "prettier:check": "yarn prettier --debug-check $npm_package_config_prettier_target",
     "prettier:write": "yarn prettier --write $npm_package_config_prettier_target",
     "eslint:check": "eslint $npm_package_config_prettier_target --max-warnings=0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES2019",
     "module": "ESNext",
     "moduleResolution": "node",
+    "declaration": true,
     "strict": true,
     "jsx": "react",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Despite the package.json specifies a TS declaration file (https://github.com/atlassian-labs/storybook-addon-performance/blob/master/package.json#L11), it doesn't get generated.

The `dist/` folder without my change after running `npm run build`:

<img width="746" alt="Screen Shot 2020-04-22 at 6 12 57 PM" src="https://user-images.githubusercontent.com/2785791/80048687-be0a6f00-84c5-11ea-934c-f21f71c386e3.png">

With my change:
<img width="740" alt="Screen Shot 2020-04-22 at 6 13 30 PM" src="https://user-images.githubusercontent.com/2785791/80048693-c367b980-84c5-11ea-885e-766a4058458b.png">
