### PR TITLE
Ignore package-lock files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
If contributors are using `npm install` to install bundles, a package-lock file gets generated. Adding this config prevents such file generation. See also: https://docs.npmjs.com/misc/config#package-lock