### PR TITLE
Support client-only tasks globally, and per-story.

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,4 @@
 import { addDecorator } from '@storybook/react';
-import { addParameters } from '@storybook/client-api';
 import { withPerformance } from '../src';
 
 addDecorator(withPerformance);

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,11 @@
 import { addDecorator } from '@storybook/react';
 import { addParameters } from '@storybook/client-api';
 import { withPerformance } from '../src';
+import { defaultAllowedGroups } from '../src/tasks/preset';
 
 addParameters({
   performance: {
-    clientOnly: false,
+    allowedGroups: defaultAllowedGroups,
   },
 });
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,12 +1,5 @@
 import { addDecorator } from '@storybook/react';
 import { addParameters } from '@storybook/client-api';
 import { withPerformance } from '../src';
-import { defaultAllowedGroups } from '../src/tasks/preset';
-
-addParameters({
-  performance: {
-    allowedGroups: defaultAllowedGroups,
-  },
-});
 
 addDecorator(withPerformance);

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,11 @@
 import { addDecorator } from '@storybook/react';
+import { addParameters } from '@storybook/client-api';
 import { withPerformance } from '../src';
+
+addParameters({
+  performance: {
+    clientOnly: false,
+  },
+});
 
 addDecorator(withPerformance);

--- a/README.md
+++ b/README.md
@@ -169,6 +169,70 @@ As seen above, the plugin exports two type definitions to assist with creating y
 - `PublicInteractionTask`: defines the object structure for an interaction task; pass an array of these tasks as a parameter to storybook, as shown above.
 - `InteractionTaskArgs`: the arguments for an interaction task's `run` function
 
+## Usage: Allowed Groups
+
+Allowed Groups allow you to control the performance information to show. The default configuration will show both server-side rendering and client-side mounting performance information. To configure this option, set the `allowedGroups` option as part of a story's parameters.
+
+You can add the parameter globally to every story in `.storybook/preview.js`:
+
+```js
+import { addDecorator, addParameters } from '@storybook/react';
+import { withPerformance } from 'storybook-addon-performance';
+
+// Only client-side mounting performance will be shown
+addParameters({
+  performance: {
+    allowedGroups: ['client'],
+  },
+});
+
+addDecorator(withPerformance);
+```
+
+Or you can add it to individual stories:
+
+> Using [Component Story Format (CSF)](https://storybook.js.org/docs/formats/component-story-format/)
+
+```js
+export const onlyClient = () => <p>A story only measuring client-side performance 👩‍💻</p>;
+
+onlyClient.story = {
+  parameters: {
+    performance: {
+      allowedGroups: ['client'],
+    },
+  },
+};
+
+export const onlyServer = () => <p>A story only measuring server-side performance ‍☁️</p>;
+
+onlyServer.story = {
+  parameters: {
+    performance: {
+      allowedGroups: ['server'],
+    },
+  },
+};
+```
+
+> Using [StoriesOf API](https://storybook.js.org/docs/formats/storiesof-api/)
+
+```js
+import MyClientComponent from './MyClientComponent';
+import MyServerComponent from './MyServerComponent';
+import { withPerformance } from 'storybook-addon-performance';
+
+storiesOf('MyClientComponent', module)
+  .addDecorator(withPerformance)
+  // applies to all stories for this entire component
+  .addParameters({ performance: { allowedGroups: ['client'] } })
+  .add('MyClientComponent', () => <MyClientComponent />)
+  // applies to this specific story
+  .add('MyServerComponent', () => <MyServerComponent />, {
+    performance: { allowedGroups: ['server'] },
+  });
+```
+
 ## Local addon development
 
 ```bash

--- a/cypress/integration/run-all.spec.tsx
+++ b/cypress/integration/run-all.spec.tsx
@@ -1,8 +1,10 @@
 import { startAllButtonId } from '../../src/selectors';
-import preset from '../../src/tasks/preset';
+import getPresets from '../../src/tasks/preset';
 import { Task, TaskGroup } from '../../src/types';
 import flatten from '../../src/util/flatten';
 import { wait } from '../custom/guards';
+
+const preset = getPresets({ clientOnly: false });
 
 describe('run all', () => {
   it('be able to run all tasks', () => {

--- a/cypress/integration/run-all.spec.tsx
+++ b/cypress/integration/run-all.spec.tsx
@@ -1,10 +1,10 @@
 import { startAllButtonId } from '../../src/selectors';
-import getPresets from '../../src/tasks/preset';
+import getPresets, { defaultAllowedGroups } from '../../src/tasks/preset';
 import { Task, TaskGroup } from '../../src/types';
 import flatten from '../../src/util/flatten';
 import { wait } from '../custom/guards';
 
-const preset = getPresets({ clientOnly: false });
+const preset = getPresets({ allowedGroups: defaultAllowedGroups });
 
 describe('run all', () => {
   it('be able to run all tasks', () => {

--- a/cypress/integration/run-single.spec.tsx
+++ b/cypress/integration/run-single.spec.tsx
@@ -1,8 +1,8 @@
-import getPresets from '../../src/tasks/preset';
+import getPresets, { defaultAllowedGroups } from '../../src/tasks/preset';
 import { Task } from '../../src/types';
 import { wait } from '../custom/guards';
 
-const preset = getPresets({ clientOnly: false });
+const preset = getPresets({ allowedGroups: defaultAllowedGroups });
 const task: Task = preset[0].tasks[0];
 
 describe('run single', () => {

--- a/cypress/integration/run-single.spec.tsx
+++ b/cypress/integration/run-single.spec.tsx
@@ -1,7 +1,8 @@
-import preset from '../../src/tasks/preset';
+import getPresets from '../../src/tasks/preset';
 import { Task } from '../../src/types';
 import { wait } from '../custom/guards';
 
+const preset = getPresets({ clientOnly: false });
 const task: Task = preset[0].tasks[0];
 
 describe('run single', () => {

--- a/examples/landing.stories.tsx
+++ b/examples/landing.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Select from 'react-select';
 import invariant from 'tiny-invariant';
 import { InteractionTaskArgs, PublicInteractionTask } from '../src';
+import { AllowedGroup } from '../src/types';
 
 export default {
   title: 'Examples',
@@ -40,7 +41,7 @@ const interactionTasks: PublicInteractionTask[] = [
 ];
 
 select.story = {
-  name: 'React select',
+  name: 'React Select',
   parameters: {
     performance: {
       interactions: interactionTasks,
@@ -66,3 +67,27 @@ function Slow() {
 }
 
 export const slow = () => <Slow />;
+
+export const onlyClientPerformance = () => <p>A story only measuring client-side performance 👩‍💻</p>;
+
+onlyClientPerformance.story = {
+  name: 'Only Client',
+  parameters: {
+    performance: {
+      allowedGroups: [AllowedGroup.Client],
+    },
+  },
+};
+
+export const onlyServerPerformance = () => (
+  <p>A story only measuring server-side performance ‍☁️</p>
+);
+
+onlyServerPerformance.story = {
+  name: 'Only Server',
+  parameters: {
+    performance: {
+      allowedGroups: [AllowedGroup.Server],
+    },
+  },
+};

--- a/examples/landing.stories.tsx
+++ b/examples/landing.stories.tsx
@@ -26,27 +26,24 @@ function SelectExample() {
 
 export const select = () => <SelectExample />;
 
-
 const interactionTasks: PublicInteractionTask[] = [
   {
     name: 'Display dropdown',
     description: 'Open the dropdown and wait for Option 5 to load',
     run: async ({ container, controls }: InteractionTaskArgs): Promise<void> => {
-      const element: HTMLElement | null = container.querySelector(
-        '.addon__dropdown-indicator',
-      );
+      const element: HTMLElement | null = container.querySelector('.addon__dropdown-indicator');
       invariant(element);
       fireEvent.mouseDown(element);
       await findByText(container, 'Option 5', undefined, { timeout: 20000 });
     },
   },
-]
+];
 
 select.story = {
   name: 'React select',
   parameters: {
     performance: {
-      interactions: interactionTasks
+      interactions: interactionTasks,
     },
   },
 };
@@ -55,7 +52,7 @@ export const noInteractions = () => <p>A story with no interactions 👋</p>;
 
 function burnCpu() {
   const start = performance.now();
-  while (performance.now() - start < 200) { }
+  while (performance.now() - start < 200) {}
 }
 
 function Slow() {

--- a/examples/landing.stories.tsx
+++ b/examples/landing.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Select from 'react-select';
 import invariant from 'tiny-invariant';
 import { InteractionTaskArgs, PublicInteractionTask } from '../src';
-import { AllowedGroup } from '../src/types';
 
 export default {
   title: 'Examples',
@@ -74,7 +73,7 @@ onlyClientPerformance.story = {
   name: 'Only Client',
   parameters: {
     performance: {
-      allowedGroups: [AllowedGroup.Client],
+      allowedGroups: ['client'],
     },
   },
 };
@@ -87,7 +86,7 @@ onlyServerPerformance.story = {
   name: 'Only Server',
   parameters: {
     performance: {
-      allowedGroups: [AllowedGroup.Server],
+      allowedGroups: ['server'],
     },
   },
 };

--- a/examples/panel.stories.tsx
+++ b/examples/panel.stories.tsx
@@ -7,6 +7,7 @@ import { savePinned } from '../src/panel/pinned-storage';
 import { bindAll } from '../src/util/bind-channel-events';
 import WithStorybookTheme from '../test-util/with-storybook-theme';
 import * as mocks from '../test-util/mocks';
+import { defaultAllowedGroups } from '../src/tasks/preset';
 
 export default {
   title: 'Panel',
@@ -34,7 +35,7 @@ function ManagedPanel({ mode }: { mode: 'dark' | 'normal' }) {
 
   return (
     <WithStorybookTheme mode={mode}>
-      <Panel channel={channel} interactions={[]} clientOnly={false} />
+      <Panel channel={channel} interactions={[]} allowedGroups={defaultAllowedGroups} />
     </WithStorybookTheme>
   );
 }

--- a/examples/panel.stories.tsx
+++ b/examples/panel.stories.tsx
@@ -34,7 +34,7 @@ function ManagedPanel({ mode }: { mode: 'dark' | 'normal' }) {
 
   return (
     <WithStorybookTheme mode={mode}>
-      <Panel channel={channel} interactions={[]} />
+      <Panel channel={channel} interactions={[]} clientOnly={false} />
     </WithStorybookTheme>
   );
 }

--- a/src/decorator/decorator.tsx
+++ b/src/decorator/decorator.tsx
@@ -11,7 +11,8 @@ export default makeDecorator({
   // 'Interactions' need to be provided by consumers
   skipIfNoParametersOrOptions: false,
   wrapper: (getStory, context, { parameters }) => {
-    const interactions: PublicInteractionTask[] | undefined = parameters && parameters.interactions;
+    const interactions: PublicInteractionTask[] = (parameters && parameters.interactions) || [];
+    const clientOnly: boolean = Boolean(parameters && parameters.clientOnly);
 
     // Sadly need to add cast channel for storybook ts-loader
     return (
@@ -19,6 +20,7 @@ export default makeDecorator({
         getNode={() => getStory(context)}
         channel={addons.getChannel() as any}
         interactions={interactions}
+        clientOnly={clientOnly}
       />
     );
   },

--- a/src/decorator/decorator.tsx
+++ b/src/decorator/decorator.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import addons, { makeDecorator } from '@storybook/addons';
 import TaskHarness from './task-harness';
-import { PublicInteractionTask } from '../types';
+import { PublicInteractionTask, AllowedGroup } from '../types';
 import * as constants from '../addon-constants';
+import { defaultAllowedGroups } from '../tasks/preset';
 
 export default makeDecorator({
   name: constants.decoratorKey,
@@ -12,7 +13,8 @@ export default makeDecorator({
   skipIfNoParametersOrOptions: false,
   wrapper: (getStory, context, { parameters }) => {
     const interactions: PublicInteractionTask[] = (parameters && parameters.interactions) || [];
-    const clientOnly: boolean = Boolean(parameters && parameters.clientOnly);
+    const allowedGroups: AllowedGroup[] =
+      (parameters && parameters.allowedGroups) || defaultAllowedGroups;
 
     // Sadly need to add cast channel for storybook ts-loader
     return (
@@ -20,7 +22,7 @@ export default makeDecorator({
         getNode={() => getStory(context)}
         channel={addons.getChannel() as any}
         interactions={interactions}
-        clientOnly={clientOnly}
+        allowedGroups={allowedGroups}
       />
     );
   },

--- a/src/decorator/task-harness.tsx
+++ b/src/decorator/task-harness.tsx
@@ -12,6 +12,7 @@ import {
   TaskGroup,
   TaskMap,
   ErrorResult,
+  AllowedGroup,
 } from '../types';
 import getElement from '../task-runner/get-element';
 import { bindAll } from '../util/bind-channel-events';
@@ -22,16 +23,16 @@ type Props = {
   getNode: () => React.ReactNode;
   channel: Channel;
   interactions: PublicInteractionTask[] | undefined;
-  clientOnly: boolean;
+  allowedGroups: AllowedGroup[];
 };
 
-export default function TaskHarness({ getNode, channel, interactions = [], clientOnly }: Props) {
+export default function TaskHarness({ getNode, channel, interactions = [], allowedGroups }: Props) {
   const groups: TaskGroup[] = useMemo(
     function merge() {
-      const preset = getPresets({ clientOnly });
+      const preset = getPresets({ allowedGroups });
       return [...preset, getInteractionGroup(interactions)];
     },
-    [interactions, clientOnly],
+    [interactions, allowedGroups],
   );
   const tasks: TaskMap = useMemo(() => getTaskMap(groups), [groups]);
 

--- a/src/decorator/task-harness.tsx
+++ b/src/decorator/task-harness.tsx
@@ -15,21 +15,23 @@ import {
 } from '../types';
 import getElement from '../task-runner/get-element';
 import { bindAll } from '../util/bind-channel-events';
-import preset from '../tasks/preset';
+import getPresets from '../tasks/preset';
 import getTaskMap from '../tasks/get-tasks-map';
 
 type Props = {
   getNode: () => React.ReactNode;
   channel: Channel;
   interactions: PublicInteractionTask[] | undefined;
+  clientOnly: boolean;
 };
 
-export default function TaskHarness({ getNode, channel, interactions = [] }: Props) {
+export default function TaskHarness({ getNode, channel, interactions = [], clientOnly }: Props) {
   const groups: TaskGroup[] = useMemo(
     function merge() {
+      const preset = getPresets({ clientOnly });
       return [...preset, getInteractionGroup(interactions)];
     },
-    [interactions],
+    [interactions, clientOnly],
   );
   const tasks: TaskMap = useMemo(() => getTaskMap(groups), [groups]);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { default as withPerformance } from './decorator/decorator';
 
 // Public types
-export { PublicInteractionTask, InteractionTaskArgs } from './types';
+export { PublicInteractionTask, InteractionTaskArgs, AllowedGroup } from './types';

--- a/src/panel/panel.tsx
+++ b/src/panel/panel.tsx
@@ -44,11 +44,6 @@ function findResult(group: TaskGroup, context: Nullable<RunContext>): Nullable<T
   return result || null;
 }
 
-function getResult(group: TaskGroup, context: RunContext): Nullable<TaskGroupResult> {
-  const result: Nullable<TaskGroupResult> = findResult(group, context);
-  return result;
-}
-
 export default function Panel({
   channel,
   interactions,
@@ -81,7 +76,7 @@ export default function Panel({
               <TaskGroupPanel
                 key={group.groupId}
                 group={group}
-                result={getResult(group, state.context.current)}
+                result={findResult(group, state.context.current)}
                 pinned={findResult(group, state.context.pinned)}
               />
             );

--- a/src/panel/panel.tsx
+++ b/src/panel/panel.tsx
@@ -3,7 +3,13 @@ import { styled } from '@storybook/theming';
 import React, { useMemo } from 'react';
 import { getInteractionGroup } from '../tasks/get-interaction-group';
 import getPresets from '../tasks/preset';
-import { Nullable, PublicInteractionTask, TaskGroup, TaskGroupResult } from '../types';
+import {
+  Nullable,
+  PublicInteractionTask,
+  TaskGroup,
+  TaskGroupResult,
+  AllowedGroup,
+} from '../types';
 import machine, { RunContext } from './machine';
 import ServiceContext from './service-context';
 import TaskGroupPanel from './task-group';
@@ -38,32 +44,28 @@ function findResult(group: TaskGroup, context: Nullable<RunContext>): Nullable<T
   return result || null;
 }
 
-function getResult(group: TaskGroup, context: RunContext): TaskGroupResult {
+function getResult(group: TaskGroup, context: RunContext): Nullable<TaskGroupResult> {
   const result: Nullable<TaskGroupResult> = findResult(group, context);
-  // Cannot use invariant as we are not at a high enough typescript version
-  if (!result) {
-    throw new Error(`Could not find group(${group.groupId}) in result`);
-  }
   return result;
 }
 
 export default function Panel({
   channel,
   interactions,
-  clientOnly,
+  allowedGroups,
 }: {
   channel: Channel;
   interactions: PublicInteractionTask[];
-  clientOnly: boolean;
+  allowedGroups: AllowedGroup[];
 }) {
   const { state, service } = usePanelMachine(machine, channel);
 
   const groups: TaskGroup[] = useMemo(
     function merge() {
-      const preset = getPresets({ clientOnly });
+      const preset = getPresets({ allowedGroups });
       return [...preset, getInteractionGroup(interactions)];
     },
-    [interactions, clientOnly],
+    [interactions, allowedGroups],
   );
 
   return (

--- a/src/panel/panel.tsx
+++ b/src/panel/panel.tsx
@@ -2,7 +2,7 @@ import { Channel } from '@storybook/channels';
 import { styled } from '@storybook/theming';
 import React, { useMemo } from 'react';
 import { getInteractionGroup } from '../tasks/get-interaction-group';
-import preset from '../tasks/preset';
+import getPresets from '../tasks/preset';
 import { Nullable, PublicInteractionTask, TaskGroup, TaskGroupResult } from '../types';
 import machine, { RunContext } from './machine';
 import ServiceContext from './service-context';
@@ -50,17 +50,20 @@ function getResult(group: TaskGroup, context: RunContext): TaskGroupResult {
 export default function Panel({
   channel,
   interactions,
+  clientOnly,
 }: {
   channel: Channel;
   interactions: PublicInteractionTask[];
+  clientOnly: boolean;
 }) {
   const { state, service } = usePanelMachine(machine, channel);
 
   const groups: TaskGroup[] = useMemo(
     function merge() {
+      const preset = getPresets({ clientOnly });
       return [...preset, getInteractionGroup(interactions)];
     },
-    [interactions],
+    [interactions, clientOnly],
   );
 
   return (

--- a/src/panel/task-group.tsx
+++ b/src/panel/task-group.tsx
@@ -16,7 +16,7 @@ const Container = styled.div`
 
 type Props = {
   group: TaskGroup;
-  result: TaskGroupResult;
+  result: Nullable<TaskGroupResult>;
   pinned: Nullable<TaskGroupResult>;
 };
 
@@ -40,6 +40,10 @@ function EmptyGroupMessage({ group }: { group: TaskGroup }) {
 }
 
 export default React.memo(function TaskGroup({ group, result, pinned }: Props) {
+  if (!result) {
+    return null;
+  }
+
   return (
     <Container>
       <Title>{group.name}</Title>

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -11,18 +11,23 @@ type EnvProps = {
   children: (args: {
     interactions: PublicInteractionTask[];
     channel: Channel;
+    clientOnly: boolean;
   }) => React.ReactElement<any>;
 };
 
 // We create a wrapper to supply all of the storybook stuff so
 // that we can test and display panel without needing any of it
 function Env({ children }: EnvProps) {
-  const parameters = useParameter(constants.paramKey, { interactions: [] });
-  const interactions: PublicInteractionTask[] = parameters.interactions;
+  const parameters = useParameter(constants.paramKey, {
+    interactions: [],
+    clientOnly: false,
+  });
+  const interactions: PublicInteractionTask[] = parameters.interactions || [];
+  const clientOnly = Boolean(parameters.clientOnly);
 
   // sadly need to add cast for storybook ts-loader
   const channel: Channel = addons.getChannel() as any;
-  return children({ channel: channel as any, interactions });
+  return children({ channel: channel as any, interactions, clientOnly });
 }
 
 addons.register(constants.addonKey, () => {
@@ -32,7 +37,9 @@ addons.register(constants.addonKey, () => {
     render: ({ active, key }) => (
       <AddonPanel active={active} key={key}>
         <Env>
-          {({ interactions, channel }) => <Panel channel={channel} interactions={interactions} />}
+          {({ interactions, channel, clientOnly }) => (
+            <Panel channel={channel} interactions={interactions} clientOnly={clientOnly} />
+          )}
         </Env>
       </AddonPanel>
     ),

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -5,13 +5,14 @@ import { AddonPanel } from '@storybook/components';
 import React from 'react';
 import * as constants from './addon-constants';
 import Panel from './panel/panel';
-import { PublicInteractionTask } from './types';
+import { PublicInteractionTask, AllowedGroup } from './types';
+import { defaultAllowedGroups } from './tasks/preset';
 
 type EnvProps = {
   children: (args: {
     interactions: PublicInteractionTask[];
     channel: Channel;
-    clientOnly: boolean;
+    allowedGroups: AllowedGroup[];
   }) => React.ReactElement<any>;
 };
 
@@ -20,14 +21,14 @@ type EnvProps = {
 function Env({ children }: EnvProps) {
   const parameters = useParameter(constants.paramKey, {
     interactions: [],
-    clientOnly: false,
+    allowedGroups: defaultAllowedGroups,
   });
   const interactions: PublicInteractionTask[] = parameters.interactions || [];
-  const clientOnly = Boolean(parameters.clientOnly);
+  const allowedGroups = parameters.allowedGroups || defaultAllowedGroups;
 
   // sadly need to add cast for storybook ts-loader
   const channel: Channel = addons.getChannel() as any;
-  return children({ channel: channel as any, interactions, clientOnly });
+  return children({ channel: channel as any, interactions, allowedGroups });
 }
 
 addons.register(constants.addonKey, () => {
@@ -37,8 +38,8 @@ addons.register(constants.addonKey, () => {
     render: ({ active, key }) => (
       <AddonPanel active={active} key={key}>
         <Env>
-          {({ interactions, channel, clientOnly }) => (
-            <Panel channel={channel} interactions={interactions} clientOnly={clientOnly} />
+          {({ interactions, channel, allowedGroups }) => (
+            <Panel channel={channel} interactions={interactions} allowedGroups={allowedGroups} />
           )}
         </Env>
       </AddonPanel>

--- a/src/task-runner/get-element.tsx
+++ b/src/task-runner/get-element.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-export default function getElement(
-  getNode: () => React.ReactNode,
-): () => React.ReactElement {
+export default function getElement(getNode: () => React.ReactNode): () => React.ReactElement {
   return () => <React.Fragment>{getNode()}</React.Fragment>;
 }

--- a/src/tasks/preset/client.tsx
+++ b/src/tasks/preset/client.tsx
@@ -8,6 +8,7 @@ import {
   TaskGroup,
   TimedTask,
   Nullable,
+  AllowedGroup,
 } from '../../types';
 import { staticTask, timedTask } from './create';
 import { UnsupportedError } from '../../task-runner/custom-errors';
@@ -165,9 +166,9 @@ const reactFiberNodeCount: StaticTask = staticTask({
   },
 });
 
-function getGroup(clientOnly: boolean): TaskGroup {
+function getGroup(allowedGroups: AllowedGroup[]): TaskGroup {
   const include = [];
-  if (!clientOnly) {
+  if (allowedGroups.includes(AllowedGroup.Server)) {
     include.push(hydrate);
   }
   const tasks = [

--- a/src/tasks/preset/client.tsx
+++ b/src/tasks/preset/client.tsx
@@ -168,7 +168,7 @@ const reactFiberNodeCount: StaticTask = staticTask({
 
 function getGroup(allowedGroups: AllowedGroup[]): TaskGroup {
   const include = [];
-  if (allowedGroups.includes(AllowedGroup.Server)) {
+  if (allowedGroups.includes('server')) {
     include.push(hydrate);
   }
   const tasks = [

--- a/src/tasks/preset/client.tsx
+++ b/src/tasks/preset/client.tsx
@@ -165,18 +165,25 @@ const reactFiberNodeCount: StaticTask = staticTask({
   },
 });
 
-const group: TaskGroup = {
-  groupId: 'Client',
-  name: 'Client 👩‍💻',
-  tasks: [
+function getGroup(clientOnly: boolean): TaskGroup {
+  const include = [];
+  if (!clientOnly) {
+    include.push(hydrate);
+  }
+  const tasks = [
     render,
     reRender,
-    hydrate,
+    ...include,
     domElementCount,
     domElementCountWithoutSvg,
     completeRender,
     reactFiberNodeCount,
-  ],
-};
+  ];
+  return {
+    groupId: 'Client',
+    name: 'Client 👩‍💻',
+    tasks,
+  };
+}
 
-export default group;
+export default getGroup;

--- a/src/tasks/preset/index.ts
+++ b/src/tasks/preset/index.ts
@@ -1,8 +1,21 @@
 import serverSide from './server-side';
 import getGroups from './client';
-import { TaskGroup } from '../../types';
+import { TaskGroup, AllowedGroup } from '../../types';
 
-export default function getPresets({ clientOnly = false }: { clientOnly: boolean }): TaskGroup[] {
-  const clientGroups = getGroups(clientOnly);
-  return clientOnly ? [clientGroups] : [serverSide, clientGroups];
+export const defaultAllowedGroups = [AllowedGroup.Server, AllowedGroup.Client];
+
+export default function getPresets({
+  allowedGroups = defaultAllowedGroups,
+}: {
+  allowedGroups: AllowedGroup[];
+}): TaskGroup[] {
+  const clientGroups = getGroups(allowedGroups);
+  const groups: TaskGroup[] = [];
+  if (allowedGroups.includes(AllowedGroup.Server)) {
+    groups.push(serverSide);
+  }
+  if (allowedGroups.includes(AllowedGroup.Client)) {
+    groups.push(clientGroups);
+  }
+  return groups;
 }

--- a/src/tasks/preset/index.ts
+++ b/src/tasks/preset/index.ts
@@ -1,7 +1,8 @@
 import serverSide from './server-side';
-import initialMount from './client';
+import getGroups from './client';
 import { TaskGroup } from '../../types';
 
-const preset: TaskGroup[] = [serverSide, initialMount];
-
-export default preset;
+export default function getPresets({ clientOnly = false }: { clientOnly: boolean }): TaskGroup[] {
+  const clientGroups = getGroups(clientOnly);
+  return clientOnly ? [clientGroups] : [serverSide, clientGroups];
+}

--- a/src/tasks/preset/index.ts
+++ b/src/tasks/preset/index.ts
@@ -2,7 +2,8 @@ import serverSide from './server-side';
 import getGroups from './client';
 import { TaskGroup, AllowedGroup } from '../../types';
 
-export const defaultAllowedGroups = [AllowedGroup.Server, AllowedGroup.Client];
+// as const prevents widening to the "string" type
+export const defaultAllowedGroups = ['server' as const, 'client' as const];
 
 export default function getPresets({
   allowedGroups = defaultAllowedGroups,
@@ -11,10 +12,10 @@ export default function getPresets({
 }): TaskGroup[] {
   const clientGroups = getGroups(allowedGroups);
   const groups: TaskGroup[] = [];
-  if (allowedGroups.includes(AllowedGroup.Server)) {
+  if (allowedGroups.includes('server')) {
     groups.push(serverSide);
   }
-  if (allowedGroups.includes(AllowedGroup.Client)) {
+  if (allowedGroups.includes('client')) {
     groups.push(clientGroups);
   }
   return groups;

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,3 +106,8 @@ export type TaskGroupResult = {
   groupId: string;
   map: ResultMap;
 };
+
+export enum AllowedGroup {
+  Client = 'Client',
+  Server = 'Server',
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,4 @@ export type TaskGroupResult = {
   map: ResultMap;
 };
 
-export enum AllowedGroup {
-  Client = 'Client',
-  Server = 'Server',
-}
+export type AllowedGroup = 'client' | 'server';

--- a/test/tasks/run-all.spec.ts
+++ b/test/tasks/run-all.spec.ts
@@ -1,10 +1,28 @@
 import { runAll } from '../../src/task-runner';
-import preset from '../../src/tasks/preset';
+import getPresets from '../../src/tasks/preset';
 import { Task, TaskGroup, TaskGroupResult, TimedResult } from '../../src/types';
 import toResultMap from '../../src/util/to-result-map';
 import { StaticResult } from '../../src/types';
 
+it('should only include client tasks', () => {
+  const clientPresets = getPresets({ clientOnly: true });
+  const groupNames = clientPresets.map((p) => p.name);
+  const groupTasks = clientPresets.reduce(
+    (acc, curr) => acc.concat(curr.tasks.map((t) => t.name)),
+    [],
+  );
+
+  expect(groupNames).toEqual(['Client 👩‍💻']);
+  expect(groupTasks).toEqual([
+    'Initial render',
+    'Re render',
+    'DOM element count',
+    'DOM element count (no nested inline svg elements)',
+  ]);
+});
+
 it('should run all the standard tests', async () => {
+  const preset = getPresets({ clientOnly: false });
   const result = await runAll({
     groups: preset,
     getNode: () => 'hey',

--- a/test/tasks/run-all.spec.ts
+++ b/test/tasks/run-all.spec.ts
@@ -1,11 +1,11 @@
 import { runAll } from '../../src/task-runner';
-import getPresets from '../../src/tasks/preset';
-import { Task, TaskGroup, TaskGroupResult, TimedResult } from '../../src/types';
+import getPresets, { defaultAllowedGroups } from '../../src/tasks/preset';
+import { Task, TaskGroup, TaskGroupResult, TimedResult, AllowedGroup } from '../../src/types';
 import toResultMap from '../../src/util/to-result-map';
 import { StaticResult } from '../../src/types';
 
 it('should only include client tasks', () => {
-  const clientPresets = getPresets({ clientOnly: true });
+  const clientPresets = getPresets({ allowedGroups: [AllowedGroup.Client] });
   const groupNames = clientPresets.map((p) => p.name);
   const groupTasks = clientPresets.reduce(
     (acc, curr) => acc.concat(curr.tasks.map((t) => t.name)),
@@ -18,11 +18,12 @@ it('should only include client tasks', () => {
     'Re render',
     'DOM element count',
     'DOM element count (no nested inline svg elements)',
+    'Complete render (mount + layout + paint)',
   ]);
 });
 
 it('should run all the standard tests', async () => {
-  const preset = getPresets({ clientOnly: false });
+  const preset = getPresets({ allowedGroups: defaultAllowedGroups });
   const result = await runAll({
     groups: preset,
     getNode: () => 'hey',

--- a/test/tasks/run-all.spec.ts
+++ b/test/tasks/run-all.spec.ts
@@ -5,7 +5,7 @@ import toResultMap from '../../src/util/to-result-map';
 import { StaticResult } from '../../src/types';
 
 it('should only include client tasks', () => {
-  const clientPresets = getPresets({ allowedGroups: [AllowedGroup.Client] });
+  const clientPresets = getPresets({ allowedGroups: ['client'] });
   const groupNames = clientPresets.map((p) => p.name);
   const groupTasks = clientPresets.reduce(
     (acc, curr) => acc.concat(curr.tasks.map((t) => t.name)),


### PR DESCRIPTION
# Overview

For projects that don't server render their components, the server-related data is not helpful.

Clients can opt-in to client-only performance tests by adding:

```javascript
import { addParameters } from '@storybook/client-api';
import { AllowedGroup } from 'storybook-addon-performance';

addParameters({
  performance: {
    allowedGroups: [AllowedGroup.Client],
  },
});
```

to their `.storybook/preview.js` file.

On a per-story basis, the `allowedGroups` parameter can be set alongside
the `interactions` parameter:

```javascript
select.story = {
  name: 'React select',
  parameters: {
    performance: {
      interactions: interactionTasks,
      allowedGroups: [AllowedGroup.Client],
    },
  },
};
```

This change removes all service-side tasks, as well as the "hydrate"
task in from the client-side group.

## Screenshots

### Before

![](https://d.pr/i/9ymFC8.png)

### After

![](https://d.pr/i/DozN8e.png)

## Documentation

I'm not sure how the maintainers want this functionality documented. The easiest place would be a small section in the `README`. There is also an `examples` directory that may be a good place to add a small example. Let me know 😄 