### PR TITLE
Fixed the task result is picking up the incorrect field for calculating difference between pinned value and actual value

### DIFF
--- a/src/panel/task-result/static-result.tsx
+++ b/src/panel/task-result/static-result.tsx
@@ -35,7 +35,7 @@ function DiffToPinned({
               <Parts.TitleCell>Current value</Parts.TitleCell>
               <Parts.ValueCell>
                 <Parts.ValueLozenge type={pinned.value === result.value ? 'raw' : 'info'}>
-                  {pinned.value}
+                  {result.value}
                   {task.scale}
                 </Parts.ValueLozenge>
               </Parts.ValueCell>

--- a/src/panel/top-bar.tsx
+++ b/src/panel/top-bar.tsx
@@ -109,7 +109,6 @@ export default function Topbar() {
               send('SET_VALUES', values);
             }}
           >
-            >
             {sizes.map((size: number) => (
               <option key={size} value={size}>
                 {size} {pluraliseSamples(size)}


### PR DESCRIPTION
@alexreardon looks there is an extra `>` in file `src/panel/top-bar.tsx`(will cause compile failure), removed it as part of the fix.