### PR TITLE
Removes `types` property from the tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "removeComments": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "types": ["gzip-js", "jest", "react", "react-dom"]
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Related issue: https://github.com/atlassian-labs/storybook-addon-performance/issues/38

The fix for the blocker of the issue has been merged and deployed in `cypress@4.6` and the [commit](https://github.com/atlassian-labs/storybook-addon-performance/commit/628c254bb374ae3d0085b91a0404e5dd576e9347) in the repository which bumped dependencies enabled the fix to be able to be applied. 