### PR TITLE
chore: update spacing of info icon

### DIFF
--- a/src/panel/task-result/parts.tsx
+++ b/src/panel/task-result/parts.tsx
@@ -32,6 +32,7 @@ export const Note =
     font-size: small;
 
     &::before {
+      margin-right: 1ch;
       content: 'ℹ️';
     }
   ` as any;


### PR DESCRIPTION
Hi guys,

Noticed a very small visual issue with the info icon in the storybook add-on. See pictures:

**Before**
![Screen Shot 2020-11-03 at 4 09 53 pm](https://user-images.githubusercontent.com/13936670/97951720-41026f80-1def-11eb-991f-18e07d24a955.png)

**After**
![Screen Shot 2020-11-03 at 4 10 29 pm](https://user-images.githubusercontent.com/13936670/97951722-42cc3300-1def-11eb-8be6-17316d97a4b6.png)

Also I was wondering if can get branch permissions for this repo?