### PR TITLE
Disable the Hydrate task on client only configs

### DIFF
--- a/src/tasks/get-groups.ts
+++ b/src/tasks/get-groups.ts
@@ -31,7 +31,13 @@ export function getGroups({
     result.push(server);
   }
   if (allowedGroups.includes('client')) {
-    result.push(client);
+    const tasks = allowedGroups.includes('server')
+      ? client.tasks
+      : client.tasks.filter((task) => task.name !== 'Hydrate');
+    result.push({
+      ...client,
+      tasks,
+    });
   }
 
   result.push(getInteractionGroup(interactions));

--- a/test/panel/group-filtering.spec.tsx
+++ b/test/panel/group-filtering.spec.tsx
@@ -15,7 +15,7 @@ import server from '../../src/tasks/preset/server';
 it('should allow filtering of tasks (client only)', () => {
   // 1: Initial render
   const channel: Channel = new Channel({ async: false });
-  const { container, queryByText } = render(
+  const { container, queryByText, debug } = render(
     <WithStorybookTheme>
       <Panel interactions={[]} channel={channel} allowedGroups={['client']} />
     </WithStorybookTheme>,
@@ -37,6 +37,14 @@ it('should allow filtering of tasks (client only)', () => {
 
   expect(queryByText(client.name)).toBeTruthy();
   expect(queryByText(server.name)).toBeFalsy();
+
+  // All tasks should be rendered except Hydrate (see #57)
+  expect(queryByText('Hydrate')).toBeFalsy();
+  client.tasks.forEach((task) => {
+    if (task.name !== 'Hydrate') {
+      expect(queryByText(task.name)).toBeTruthy();
+    }
+  });
 });
 
 it('should allow filtering of tasks (server only)', () => {
@@ -64,4 +72,7 @@ it('should allow filtering of tasks (server only)', () => {
 
   expect(queryByText(client.name)).toBeFalsy();
   expect(queryByText(server.name)).toBeTruthy();
+  server.tasks.forEach((task) => {
+    expect(queryByText(task.name)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Closes #57 

There are obviously several ways to do this. I chose not to do it in `preset/client.tsx` because it would have required to export a function (taking an allowedGroups param) instead of an object (which is the current export in both the client and server presets).

I think that filtering the tasks in get-groups is a good option because the allowedGroups is already in use there, but I realise that this introduces some extra complexity (it will break if we change the Hydrate task's name).

Happy to take any feedback!