### PR TITLE
Follow-up changes from "Disable the Hydrate task on client only configs" (#58)

### DIFF
--- a/src/tasks/get-groups.ts
+++ b/src/tasks/get-groups.ts
@@ -31,6 +31,8 @@ export function getGroups({
     result.push(server);
   }
   if (allowedGroups.includes('client')) {
+    // Hydration, although run client-side, relies on renderToString and
+    // should not be run if the plugin is configured to be client-only
     const tasks = allowedGroups.includes('server')
       ? client.tasks
       : client.tasks.filter((task) => task.name !== 'Hydrate');

--- a/test/panel/group-filtering.spec.tsx
+++ b/test/panel/group-filtering.spec.tsx
@@ -15,7 +15,7 @@ import server from '../../src/tasks/preset/server';
 it('should allow filtering of tasks (client only)', () => {
   // 1: Initial render
   const channel: Channel = new Channel({ async: false });
-  const { container, queryByText, debug } = render(
+  const { container, queryByText } = render(
     <WithStorybookTheme>
       <Panel interactions={[]} channel={channel} allowedGroups={['client']} />
     </WithStorybookTheme>,


### PR DESCRIPTION
- [x] adds a small comment to the code explaining why the hydrate task is being excluded from client tasks when server is not an allowed group
- [x] removes debug from the test file