### PR TITLE
chore: cjs uses es5

### DIFF
--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "outDir": "dist/cjs",
     "module": "CommonJS",
+    "target": "ES5",
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -4,5 +4,13 @@
     "outDir": "dist/cjs",
     "module": "CommonJS",
     "target": "ES5",
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "lib": [
+      "DOM",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2019"
+    ]
   }
 }


### PR DESCRIPTION
Update to down compile CJS