### PR TITLE
:zap: chore: Fixed yarn warning

### DIFF
--- a/packages/storybook-addon-performance/package.json
+++ b/packages/storybook-addon-performance/package.json
@@ -35,6 +35,7 @@
     "@testing-library/jest-dom": "^5.11.2",
     "@xstate/react": "^1.5.1",
     "gzip-js": "^0.3.2",
+    "react-is": "16.8.0",
     "styled-components": "^5.1.1",
     "tiny-invariant": "^1.1.0",
     "xstate": "^4.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9079,6 +9079,11 @@ react-input-autosize@^3.0.0:
   dependencies:
     prop-types "^15.5.8"
 
+react-is@16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.0.tgz#518db476214f3fb0716af9f82dfd420225ae970f"
+  integrity sha512-LOy+3La39aduxaPfuj+lCXC5RQ8ukjVPAAsFJ3yQ+DIOLf4eR9OMKeWKF0IzjRyE95xMj5QELwiXGgfQsIJguA==
+
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Fixes #106 
I added react-is to dependencies to fix a yarn warning of missing peer-dependency from styled-components.