### PR TITLE
fix: Remove xstate utils

### DIFF
--- a/.changeset/lazy-knives-vanish.md
+++ b/.changeset/lazy-knives-vanish.md
@@ -1,0 +1,5 @@
+---
+'storybook-addon-performance': patch
+---
+
+Removes `xstate/lib/utils` usage which was causing errors for mjs consumption.

--- a/packages/storybook-addon-performance/src/tasks/get-tasks-map.ts
+++ b/packages/storybook-addon-performance/src/tasks/get-tasks-map.ts
@@ -1,9 +1,10 @@
 import { Task, TaskGroup, TaskMap } from '../types';
-import { flatten } from 'xstate/lib/utils';
 
 export default function getTaskMap(groups: TaskGroup[]): TaskMap {
-  return flatten(groups.map((group) => group.tasks)).reduce((acc: TaskMap, task: Task) => {
-    acc[task.name] = task;
-    return acc;
-  }, {});
+  return groups
+    .flatMap((group) => group.tasks)
+    .reduce((acc: TaskMap, task: Task) => {
+      acc[task.name] = task;
+      return acc;
+    }, {});
 }


### PR DESCRIPTION
The import `xstate/lib/utils` was not being consumed correctly by consumers using the `mjs` bundle. This addresses that.

Resolves #132.