### PR TITLE
fix: Storybook expecting package.json export

### DIFF
--- a/packages/storybook-addon-performance/package.json
+++ b/packages/storybook-addon-performance/package.json
@@ -92,7 +92,8 @@
       "require": "./dist/manager.js",
       "import": "./dist/manager.mjs",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
# Why?

Fix #148 after Storybook made some changes with `7.5` expecting the `package.json` to be exported. Having the `package.json` exportable helps when defining the import syntax, references, and build tools.